### PR TITLE
add_view_login&registration

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery
 //= require rails-ujs
 //= require activestorage
 //= require turbolinks

--- a/app/assets/javascripts/user-new.js
+++ b/app/assets/javascripts/user-new.js
@@ -1,0 +1,14 @@
+$(function () {
+
+  var pwd = $(".user-pass");
+  var pwd_check = $(".user-new__field--check");
+
+  pwd_check.change(function () {
+    if ($(this).prop('checked')) {
+      pwd.attr('type', 'text');
+    } else {
+      pwd.attr('type', 'password');
+    }
+  })
+
+});

--- a/app/assets/stylesheets/config/_colors.scss
+++ b/app/assets/stylesheets/config/_colors.scss
@@ -1,1 +1,4 @@
 $user-new-bgc: #f5f5f5;
+$light_dark: #333;
+$light_gray: #888;
+$light_blue: #2CCCD1;

--- a/app/assets/stylesheets/modules/_users.scss
+++ b/app/assets/stylesheets/modules/_users.scss
@@ -1,20 +1,18 @@
 .user-new{
-  height: 100vh;
-  width: 100vw;
   background-color: $user-new-bgc;
   &__header{
     height: 128px;
     width: 100%;
     text-align: center;
-    &__logo{
-      margin-top: 40px;
-      height: 49px;
-      width: 185px;
-    }
+  }
+  &--logo{
+    margin-top: 40px;
+    height: 49px;
+    width: 185px;
   }
   &__main{
     width: 700px;
-    min-height: 1000px;
+    padding-bottom: 64px;
     margin: 0 auto;
     background-color: white;
   }
@@ -38,12 +36,15 @@
       font-size: 14px;
     }
     &--require{
-      background: #ea352d;
+      background-color: $light_blue;
       margin-left: 8px;
       padding: 4px;
       border-radius: 2px;
       color: white;
       font-size: 12px;
+      &--any{
+        background-color: $light_gray;
+      }
     }
     &--input{
       width: 309px;
@@ -52,10 +53,139 @@
       border-radius: 4px;
       border: 1px solid #ccc;
       font-size: 16px;
-      // &:active{
-      //   border-color: black;
-      //   color: blue;
-      // }
     }
+    &--checkBox{
+      padding: 10px 0;
+      color: $light_dark;
+      font-size: 14px;
+    }
+    &--check{
+      width: 20px;
+      height: 20px;
+      border-radius: 2px;
+      border: 1px solid #ccc;
+      vertical-align: top;
+      transition: all ease-out .3s;
+    }
+    &__identification{
+      margin-top: 8px;
+      font-size: 14px;
+      color: $light_dark;
+    }
+    &--half{
+      width: calc(50% - 6px);
+      &:first-of-type {
+        margin-right: 8px;
+      }
+    }
+    &--birthday{
+      line-height: 48px;
+      padding-top: 8px;
+      color: $light_dark;
+      & select{
+        height: 48px;
+        width: 76px;
+        padding: 0 16px;
+        border-radius: 4px;
+        border: 1px solid #ccc;
+        font-size: 16px;
+        cursor: pointer;
+        &:not(:first-of-type){
+          margin-left: 8px;
+        }
+      }
+      &--text{
+        padding-top: 8px;
+        font-size: 14px;
+        color: $light_gray;
+      }
+    }
+    &--anounce{
+      font-size: 14px;
+      text-align: center;
+    }
+    &--submit{
+      display: block;
+      width: 100%;
+      line-height: 48px;
+      font-size: 14px;
+      border: none;
+      transition: all ease-out .3s;
+      cursor: pointer;
+      text-align: center;
+      background-color: $light_blue;
+      color: white;
+      outline: none;
+      &:focus {
+        outline:0;
+      }
+    }
+    &--confirmation{
+      font-size: 14px;
+      text-align: right;
+    }
+    &--english{
+      background-color: $user-new-bgc;
+      padding: 8px 16px;
+      font-size: 10px;
+      color: $light_gray;
+    }
+  }
+  &-link a{
+    text-decoration: none;
+    color: #0099e8;
+    &:hover{
+      text-decoration: underline;
+    }
+  }
+  &__footer{
+    width: 456px;
+    height: 140px;
+    margin: 0 auto;
+    text-align: center;
+    padding: 40px 0;
+    & ul{
+      width: 100%;
+    }
+    & li{
+      display: block;
+      color: $light_dark;
+      font-size: 12px;
+      padding-right: 10px;
+      display: inline-block;
+    }
+    &--text{
+      font-size: 13px;
+      color: $light_dark;
+    }
+  }
+}
+
+.user-login{
+  width: 456px;
+  margin: 0 auto;
+  background-color: white;
+  &__no-account{
+    text-align: center;
+    padding: 40px 64px;
+    border-bottom: 1px solid $user-new-bgc;
+  }
+  &--btn a{
+    display: block;
+    width: 100%;
+    margin-top: 25px;
+    border: 1px solid #F5B759;
+    background: #F5B759;
+    color: white;
+    line-height: 40px;
+    cursor: pointer;
+    text-decoration: none;
+    &:focus {
+      outline:0;
+    }
+  }
+
+  &__main{
+    padding: 0 57px 40px;
   }
 }

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/plataformatec/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(sign_up_params)
+    unless @user.valid?
+      flash.now[:alert] = @user.errors.full_messages
+      render :new and return
+    end
+    session["devise.regist_data"] = {user: @user.attributes}
+    session["devise.regist_data"][:user]["password"] = params[:user][:password]
+    @address = @user.build_user_address
+    render :new_address
+  end
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_one :user_address
 end

--- a/app/models/user_address.rb
+++ b/app/models/user_address.rb
@@ -1,0 +1,3 @@
+class UserAddress < ApplicationRecord
+  belongs_to :user, optional: true
+end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,54 +1,93 @@
--# %h2 Sign up
--# = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
--#   = render "devise/shared/error_messages", resource: resource
--#   .field
--#     = f.label :email
--#     %br/
--#     = f.email_field :email, autofocus: true, autocomplete: "email"
--#   .field
--#     = f.label :password
--#     - if @minimum_password_length
--#       %em
--#         (#{@minimum_password_length} characters minimum)
--#     %br/
--#     = f.password_field :password, autocomplete: "new-password"
--#   .field
--#     = f.label :password_confirmation
--#     %br/
--#     = f.password_field :password_confirmation, autocomplete: "new-password"
--#   .actions
--#     = f.submit "Sign up"
--# = render "devise/shared/links"
 .user-new
-  .user-new__header
-    .user-new__header__top
-      = link_to root_path do
-        %image.icon{src: "/assets/logo.png", class: "user-new__header__logo"}
+  = render 'devise/shared/header'
   .user-new__main
-    .user-new__container
-      .user-new__registration
-        会員情報入力
-      .user-new__field
-        %label.user-new__field--text
-          ニックネーム
-        %span.user-new__field--require
-          必須
-        %input.user-new__field--input
-      .user-new__field
-        %label.user-new__field--text
-          メールアドレス
-        %span.user-new__field--require
-          必須
-        %input.user-new__field--input
-      .user-new__field
-        %label.user-new__field--text
-          パスワード
-        %span.user-new__field--require
-          必須
-        %input.user-new__field--input
-      .user-new__field
-        %label.user-new__field--text
-          パスワード（確認）
-        %span.user-new__field--require
-          必須
-        %input.user-new__field--input
+    .user-new__registration
+      会員情報入力
+    = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+      .user-new__container
+        .user-new__field
+          %label.user-new__field--text
+            ニックネーム
+          %span.user-new__field--require
+            必須
+          %input.user-new__field--input{placeholder: "例）フリマ太郎"}
+        .user-new__field
+          %label.user-new__field--text
+            メールアドレス
+          %span.user-new__field--require
+            必須
+          = f.email_field :email, class: "user-new__field--input", placeholder: "PC・携帯どちらでも可"
+        .user-new__field
+          %label.user-new__field--text
+            パスワード
+          %span.user-new__field--require
+            必須
+          = f.password_field :password, autocomplete: "new-password", class: "user-new__field--input user-pass", placeholder: "8文字以上で入力してください"
+        .user-new__field
+          %label.user-new__field--text
+            パスワード（確認）
+          %span.user-new__field--require
+            必須
+          = f.password_field :password_confirmation, autocomplete: "new-password", class: "user-new__field--input user-pass", placeholder: "もう1度入力してください"
+          .user-new__field--checkBox
+            %input.user-new__field--check{type: "checkbox"}
+            パスワードを表示する
+        .user-new__field
+          %label.user-new__field--text.user-new__field__identification
+            本人確認
+          %div.user-new__field__identification
+            安心・安全にご利用いただくために、お客さまの本人情報の登録にご協力ください。他のお客さまに公開されることはありません。
+        .user-new__field
+          %label.user-new__field--text
+            お名前(全角) 
+          %span.user-new__field--require
+            必須
+          .display-flex
+            %input.user-new__field--input.user-new__field--half{placeholder: "例）大石"}
+            %input.user-new__field--input.user-new__field--half{placeholder: "例）海渡"}
+        .user-new__field
+          %label.user-new__field--text
+            お名前カナ(全角) 
+          %span.user-new__field--require
+            必須
+          .display-flex
+            %input.user-new__field--input.user-new__field--half{placeholder: "例）オオイシ"}
+            %input.user-new__field--input.user-new__field--half{placeholder: "例）カイト"}
+        .user-new__field
+          %label.user-new__field--text
+            生年月日
+          %span.user-new__field--require
+            必須
+          .user-new__field--birthday
+            %select.user-new__field--select
+              %option --
+            年      
+            %select.user-new__field--select
+              %option --
+            月
+            %select.user-new__field--select
+              %option --
+            日
+          .user-new__field--birthday--text
+            ※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。
+        .user-new__field
+          .user-new__field--anounce.user-new-link 
+            %p
+              「次へ進む」のボタンを押すことにより、
+              = link_to "利用規約", root_path
+              に同意したものとみなします
+        .user-new__field
+          %input.user-new__field--submit{type: "submit", value: "次へ進む"}
+        .user-new__field
+          .user-new__field--confirmation.user-new-link
+            = link_to root_path do
+              本人情報の登録について
+              %i.fa.fa-angle-right
+        .user-new__field
+          .user-new__field--english.user-new-link
+            This site is protected by reCAPTCHA and the Google 
+            = link_to "Privacy Policy", root_path
+            and 
+            = link_to "Terms of Service", root_path
+            apply.
+  = render 'devise/shared/footer'

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -1,0 +1,45 @@
+.user-new
+  = render 'devise/shared/header'
+  .user-new__main
+    .user-new__registration
+      住所入力
+    .user-new__container
+      .user-new__field
+        %label.user-new__field--text
+          郵便番号
+        %span.user-new__field--require
+          必須
+        %input.user-new__field--input{placeholder: "例）〒123-0000"}
+      .user-new__field
+        %label.user-new__field--text
+          都道府県
+        %span.user-new__field--require
+          必須
+        %input.user-new__field--input{placeholder: "例）東京都"}
+      .user-new__field
+        %label.user-new__field--text
+          市区町村
+        %span.user-new__field--require
+          必須
+        %input.user-new__field--input{placeholder: "例）横浜市緑区"}
+      .user-new__field
+        %label.user-new__field--text
+          番地
+        %span.user-new__field--require
+          必須
+        %input.user-new__field--input{placeholder: "例）青山1-1-1"}
+      .user-new__field
+        %label.user-new__field--text
+          建物名
+        %span.user-new__field--require.user-new__field--require--any
+          任意
+        %input.user-new__field--input{placeholder: "例）フォンティスビル101"}
+      .user-new__field
+        %label.user-new__field--text
+          電話番号
+        %span.user-new__field--require
+          必須
+        %input.user-new__field--input{placeholder: "例）0120117117"}
+      .user-new__field
+        %input.user-new__field--submit{type: "submit", value: "登録する"}
+  = render 'devise/shared/footer'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,17 +1,16 @@
-%h2 Log in
-= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .field
-    = f.label :password
-    %br/
-    = f.password_field :password, autocomplete: "current-password"
-  - if devise_mapping.rememberable?
-    .field
-      = f.check_box :remember_me
-      = f.label :remember_me
-  .actions
-    = f.submit "Log in"
-= render "devise/shared/links"
+.user-new
+  = render 'devise/shared/header'
+  .user-login
+    .user-login__no-account
+      アカウントをお持ちでない方はこちら
+      .user-login--btn
+        = link_to new_user_registration_path do
+          新規会員登録
+    .user-login__main
+      .user-new__field
+        %input.user-new__field--input{placeholder: "例）メールアドレス"}
+      .user-new__field
+        %input.user-new__field--input{placeholder: "例）パスワード"}
+      .user-new__field
+        %input.user-new__field--submit{type: "submit", value: "ログイン"}
+  = render 'devise/shared/footer'

--- a/app/views/devise/shared/_footer.html.haml
+++ b/app/views/devise/shared/_footer.html.haml
@@ -1,0 +1,9 @@
+.user-new__footer
+  %ul.text-center
+    %li プライバシーポリシー
+    %li フリマ利用規約
+    %li 特定商取引に関する表記
+  = link_to root_path do
+    %image.icon{src: "/assets/logo.png", class: "user-new--logo"}
+  .text-center.user-new__footer--text
+    © Furima, Inc.

--- a/app/views/devise/shared/_footer.html.haml
+++ b/app/views/devise/shared/_footer.html.haml
@@ -4,6 +4,6 @@
     %li フリマ利用規約
     %li 特定商取引に関する表記
   = link_to root_path do
-    %image.icon{src: "/assets/logo.png", class: "user-new--logo"}
+    = image_tag asset_path('logo.png'), class: "user-new--logo"
   .text-center.user-new__footer--text
     © Furima, Inc.

--- a/app/views/devise/shared/_header.html.haml
+++ b/app/views/devise/shared/_header.html.haml
@@ -1,0 +1,4 @@
+.user-new__header
+  .user-new__header__top
+    = link_to root_path do
+      %image.icon{src: "/assets/logo.png", class: "user-new--logo"}

--- a/app/views/devise/shared/_header.html.haml
+++ b/app/views/devise/shared/_header.html.haml
@@ -1,4 +1,4 @@
 .user-new__header
   .user-new__header__top
     = link_to root_path do
-      %image.icon{src: "/assets/logo.png", class: "user-new--logo"}
+      = image_tag asset_path('logo.png'), class: "user-new--logo"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations',
+  }
+  devise_scope :user do
+    get 'user_address', to: 'users/registrations#new_address'
+    post 'user_address', to: 'users/registrations#create_address'
+  end
   root 'posts#index'
 end

--- a/db/migrate/20200605020549_create_user_addresses.rb
+++ b/db/migrate/20200605020549_create_user_addresses.rb
@@ -1,0 +1,8 @@
+class CreateUserAddresses < ActiveRecord::Migration[5.2]
+  def change
+    create_table :user_addresses do |t|
+      t.references :user, foreign_key: true, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_04_012557) do
+ActiveRecord::Schema.define(version: 2020_06_05_020549) do
+
+  create_table "user_addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_user_addresses_on_user_id"
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -24,4 +31,5 @@ ActiveRecord::Schema.define(version: 2020_06_04_012557) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "user_addresses", "users"
 end

--- a/test/fixtures/user_addresses.yml
+++ b/test/fixtures/user_addresses.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/user_address_test.rb
+++ b/test/models/user_address_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class UserAddressTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# what
【マークアップ】ユーザー新規登録/ログインページ
# why
ログイン機能実装にページが必要だから

# 補足
view/devise/registrations/new.html.hamlのページは、
new_addressページ（user_addressの入力フォーム）に画面遷移するために
必要な情報のみを書いてありますが、現時点では問題ありません。
user_addressカラムも画面遷移するのに必要もカラムのみを記述しています。
サーバーサイド実装時に必要なカラムを全て記述します。

# ログインページの画像
<img width="1440" alt="ログイン画面" src="https://user-images.githubusercontent.com/61116343/83855919-bfc98280-a753-11ea-8691-4df8d94ca340.png">
<img width="633" alt="新規登録1" src="https://user-images.githubusercontent.com/61116343/83855925-c1934600-a753-11ea-8bd8-3f2fe3ccad85.png">
<img width="699" alt="新規登録2" src="https://user-images.githubusercontent.com/61116343/83855932-c2c47300-a753-11ea-8dd1-edca2868958f.png">
<img width="571" alt="新規登録3" src="https://user-images.githubusercontent.com/61116343/83855935-c48e3680-a753-11ea-8535-ccaa97b58a47.png">
