### PR TITLE
商品詳細のサーバーサイド作成とturbolinksの削除

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,6 @@
 class PostsController < ApplicationController
   before_action :set_post, except: [:index, :new, :create]
+  before_action :set_parents, only: [:new, :create]
 
   def index
     @posts = Post.includes(:post_images)
@@ -8,20 +9,27 @@ class PostsController < ApplicationController
   def new
     @post = Post.new
     @post.post_images.new
-    @parents = Category.all.order("id asc").limit(13)
   end
 
   def create
     @post = Post.new(post_params)
-    if @post.save
-      redirect_to root_path
+    if @post.post_images.present?
+      if @post.save
+        redirect_to root_path
+      else
+        render action: :new
+      end
     else
-      render :new
+      render partial:"form" ,locals: {post:new}
     end
   end
 
   def edit
     
+  end
+
+  def show
+    @images = @post.post_images.includes(:post)
   end
 
   def update
@@ -47,6 +55,10 @@ class PostsController < ApplicationController
 
   def set_post
     @post = Post.find(params[:id])
+  end
+
+  def set_parents
+    @parents = Category.all.order("id asc").limit(13)
   end
 
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -14,7 +14,7 @@ class PostsController < ApplicationController
   def create
     @post = Post.new(post_params)
     if @post.save
-      redirect_to new_post_path
+      redirect_to root_path
     else
       render :new
     end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,10 +5,8 @@
     %title FleamarketSample76d
     = csrf_meta_tags
     = csp_meta_tag
-    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
-    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     %script{crossorigin: "anonymous", src: "https://kit.fontawesome.com/b167c0ffa1.js"}
     = yield

--- a/app/views/posts/_form.html.haml
+++ b/app/views/posts/_form.html.haml
@@ -10,7 +10,6 @@
   = form.select :user_address, Post.user_addresses.keys
   = form.select :shipping, Post.shippings.keys
   = form.text_field :price
-  = form.text_field :delivery_fee
   #image-box
     #previews
       - if @post.persisted?

--- a/app/views/posts/show.html.haml
+++ b/app/views/posts/show.html.haml
@@ -1,0 +1,46 @@
+%div
+  商品名
+  = @post.name
+%div
+  - @images.each_with_index do |i, index|
+    -# 画像1枚目とそれ以外でサイズを変更したいので、番号で管理
+    - if index == 0
+      %div
+        画像1枚目（サイズ大）
+        = image_tag "#{i.image}", class: "first_image"
+    - else
+      %div
+        画像2枚目以降（サイズ小）
+        = image_tag "#{i.image}", class: "sub-image"
+%div
+  価格  
+  = @post.price
+%div
+  商品説明
+  = @post.introduce
+
+%div
+  出品者
+  = @post.user.nickname
+%div
+  カテゴリー
+  = @post.category.name
+%div
+  商品の状態
+  = @post.status
+%div
+  配送料の負担
+  = @post.delivery_status
+%div
+  発送元の地域
+  = @post.user_address
+%div
+  発送日の目安
+  = @post.shipping
+  
+-# リンク-------------------------
+- if user_signed_in? && current_user.id == @post.user_id
+  = link_to "編集", edit_post_path(@post)
+  = link_to "削除", post_path(@post), method: :delete
+- if user_signed_in? && current_user.id != @post.user_id
+  ここに購入リンクを置く予定です

--- a/db/migrate/20200610103554_delete_column_from_deliver_fee.rb
+++ b/db/migrate/20200610103554_delete_column_from_deliver_fee.rb
@@ -1,0 +1,5 @@
+class DeleteColumnFromDeliverFee < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :posts, :delivery_fee, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_08_062343) do
+ActiveRecord::Schema.define(version: 2020_06_10_103554) do
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 2020_06_08_062343) do
     t.string "name", null: false
     t.text "introduce", null: false
     t.bigint "category_id", null: false
-    t.integer "delivery_fee", null: false
     t.integer "user_address", null: false
     t.integer "shipping", null: false
     t.integer "price", null: false


### PR DESCRIPTION
# what
1．商品詳細ページのサーバーサイドを実装しました
2．turbolinksを削除
3．derivery_feeカラムを削除
# why
1．商品詳細ページを閲覧した時に必要な情報を表示するため
2．turbolinksがあると正しくJavascriptが機能しないため
3．使用してないカラムだったため
<img width="352" alt="商品詳細ページ" src="https://user-images.githubusercontent.com/61116343/84262086-ed4d6c00-ab57-11ea-9f4d-50d2355e200b.png">